### PR TITLE
feat(interrupts): adds interrupt support to CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An Intel 8080 CPU emulator, written in Go.  This project uses [my Intel 8080 CPU
 - :white_check_mark: Rotate (4 instructions)
 - :white_check_mark: Specials (4 instructions)
 - :x: Input/output (2 instructions)
-- :x: Control (4 instructions)
+- :white_check_mark: Control (4 instructions)
 
 ## Future enhancements
 - Replace the memory locations in tests with labels once the assembler supports them.

--- a/pkg/cpu/execute.go
+++ b/pkg/cpu/execute.go
@@ -878,9 +878,9 @@ func (cpu *CPU) Execute(opCode byte) error {
 
 	// CONTROL
 	case 0xFB: // EI - Enable interrupts
-		return errNotImplemented(opCode)
+		cpu.interruptEnabled = true
 	case 0xF3: // DI - Disable interrupts
-		return errNotImplemented(opCode)
+		cpu.interruptEnabled = false
 	case 0x00: // NOP - No-operation
 		// Do nothing
 	case 0x76: // HLT - Halt

--- a/pkg/cpu/opcodes.go
+++ b/pkg/cpu/opcodes.go
@@ -348,7 +348,7 @@ func (cpu *CPU) ret(condition bool) error {
 func (cpu *CPU) rst(address types.Word) error {
 	err := cpu.push(cpu.programCounter)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not push() cpu.programCounter: 0x%04X: %v", cpu.programCounter, err)
 	}
 
 	cpu.programCounter = address


### PR DESCRIPTION
- This PR adds interrupt support to the CPU emulator.  I haven't written tests for the EI and DI functions, nor the interrupts themselves, as they rely on an external piece of hardware (emulated or not) to trigger the interrupt routine.  Perhaps in the future, I can create a Go routine that triggers the `interruptPending` flag outside the normal `Execute()` workflow.