### PR TITLE
feat(io): implements the input/output instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ An Intel 8080 CPU emulator, written in Go.  This project uses [my Intel 8080 CPU
 - :white_check_mark: Logical (36 instructions)
 - :white_check_mark: Rotate (4 instructions)
 - :white_check_mark: Specials (4 instructions)
-- :x: Input/output (2 instructions)
+- :white_check_mark: Input/output (2 instructions)
 - :white_check_mark: Control (4 instructions)
 
 ## Future enhancements

--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -16,15 +16,16 @@ type Flags struct {
 }
 
 type CPU struct {
-	A    byte
-	B, C byte
-	D, E byte
-	H, L byte
-
+	A     byte
+	B, C  byte
+	D, E  byte
+	H, L  byte
 	flags Flags
 
 	stackPointer   types.Word
 	programCounter types.Word
+
+	ports map[byte]byte
 
 	interruptEnabled     bool
 	interruptPending     bool
@@ -41,7 +42,10 @@ type Bus interface {
 }
 
 func New() *CPU {
-	return &CPU{Bus: memory.New()}
+	return &CPU{
+		Bus:   memory.New(),
+		ports: make(map[byte]byte, 256),
+	}
 }
 
 func (cpu *CPU) Load(data []byte) error {

--- a/pkg/cpu/execute.go
+++ b/pkg/cpu/execute.go
@@ -872,9 +872,17 @@ func (cpu *CPU) Execute(opCode byte) error {
 
 	// INPUT/OUTPUT
 	case 0xDB: // IN - Input
-		return errNotImplemented(opCode)
+		fetchedByte, err := cpu.fetchByte()
+		if err != nil {
+			return err
+		}
+		cpu.in(fetchedByte)
 	case 0xD3: // OUT - Output
-		return errNotImplemented(opCode)
+		fetchedByte, err := cpu.fetchByte()
+		if err != nil {
+			return err
+		}
+		cpu.out(fetchedByte)
 
 	// CONTROL
 	case 0xFB: // EI - Enable interrupts

--- a/pkg/cpu/opcodes.go
+++ b/pkg/cpu/opcodes.go
@@ -355,6 +355,16 @@ func (cpu *CPU) rst(address types.Word) error {
 	return nil
 }
 
+// in reads an 8-bit value from the port specified in the port parameter
+func (cpu *CPU) in(port byte) {
+	cpu.A = cpu.ports[port]
+}
+
+// out writes the value of the accumulator to the port specified in the port parameter
+func (cpu *CPU) out(port byte) {
+	cpu.ports[port] = cpu.A
+}
+
 // joinBytes combines two bytes into a 16-bit word.
 //
 // This function takes a high byte and a low byte and joins them to form
@@ -459,9 +469,4 @@ func (cpu *CPU) setM(value byte) error {
 	}
 
 	return nil
-}
-
-// ErrNotImplemented is a temporary function to be removed when all instructions are implemented
-func errNotImplemented(opCode byte) error {
-	return fmt.Errorf("instruction 0x%02X not implemented", opCode)
 }


### PR DESCRIPTION
- This PR implements the input/output instructions (`IN`/`OUT`).  These instructions aren't currently used in the CPU as they rely on having external devices connected (which don't exist). Nonetheless, they are implemented for completeness and may be refactored at some point.
- Also removes the `errNotImplemented` error as all instructions have been implemented. 🥳 